### PR TITLE
Fix restore_state_when_connected boolean order

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -583,7 +583,7 @@ class LocalTuyaEntity(RestoreEntity, pytuya.ContextualLogger):
         restore_state = self._state
 
         # If no state stored in the entity currently, go from last saved state
-        if (restore_state == STATE_UNKNOWN) | (restore_state is None):
+        if (restore_state is None) or (restore_state == STATE_UNKNOWN):
             self.debug("No current state for entity")
             restore_state = self._last_state
 


### PR DESCRIPTION
## Summary
- reorder boolean check in `restore_state_when_connected` to check for `None` first

## Testing
- `python -m py_compile custom_components/localtuya/common.py`
- `tox` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e5e4ea6c8333a9d748ba49437233